### PR TITLE
Add multifile support; fix styling for focussed input

### DIFF
--- a/ui/components/UIDynamicForm.vue
+++ b/ui/components/UIDynamicForm.vue
@@ -370,6 +370,7 @@ export default {
                     }
                 }
             case 'file':
+                const multiple = field.customForm ? JSON.parse(field.customForm).multiple === 'true' : false
                 return {
                     type: 'FormKit',
                     props: {
@@ -387,6 +388,7 @@ export default {
                         // innerClass: ui-dynamic-form-input-outlines `${this.theme === 'dark' ? '$remove:formkit-inner' : ''}`,
                         readonly: isReadOnly,
                         disabled: isReadOnly,
+                        multiple,
                         validation,
                         validationVisibility: 'live'
                     }

--- a/ui/stylesheets/ui-dynamic-form.css
+++ b/ui/stylesheets/ui-dynamic-form.css
@@ -181,8 +181,9 @@ code {
   margin: 0px;
 }
 
-.reset-background {
-    --fk-bg-input: none; /*maybe none or (revert)*/
+.reset-background, .reset-background .formkit-input:focus {
+    --fk-bg-input: none !important; /*maybe none or (revert)*/
+    background-color: var(--fk-bg-input) !important;
 }
 
 .custom-fieldset {


### PR DESCRIPTION
Wenn man im Studio multifile auswählt ist es jetzt auch möglich mehrere Dateien im Upload-Dialog auszuwählen.
Wenn man das Element fokussiert kann man nun weiterhin den Text lesen.