### PR TITLE
Fix Button Styling For Long Texts

### DIFF
--- a/ui/stylesheets/ui-dynamic-form.css
+++ b/ui/stylesheets/ui-dynamic-form.css
@@ -168,7 +168,8 @@ code {
   min-height: 36px;
   padding: 8px 12px;
   box-sizing: border-box;
-  flex-shrink: 0;
+  white-space: normal;
+  word-wrap: break-word;
 }
 
 @media screen and (min-width: 600px) {
@@ -177,10 +178,8 @@ code {
   }
 
   .ui-dynamic-form-footer-action-button {
-    max-width: 200px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
+    word-wrap: break-word;
   }
 }
 
@@ -287,15 +286,13 @@ code {
     font-size: 16px;
     width: 100%;
     box-sizing: border-box;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    white-space: normal;
+    word-wrap: break-word;
   }
 
   .ui-dynamic-form-footer-action-button .v-btn__content {
-    white-space: nowrap !important;
-    overflow: hidden !important;
-    text-overflow: ellipsis !important;
+    white-space: normal !important;
+    word-wrap: break-word !important;
     max-width: 100% !important;
     display: block !important;
   }
@@ -310,9 +307,8 @@ code {
 
   .ui-dynamic-form-footer-action-primary .v-btn__content,
   .ui-dynamic-form-footer-action-secondary .v-btn__content {
-    white-space: nowrap !important;
-    overflow: hidden !important;
-    text-overflow: ellipsis !important;
+    white-space: normal !important;
+    word-wrap: break-word !important;
     max-width: 100% !important;
     display: block !important;
   }


### PR DESCRIPTION
- Auf Desktop wird der Button breiter wenn mehr Text als Label genutzt wird
- Auf Mobile wird der Text gewrapped damit er voll zu sehen ist
<img width="683" height="413" alt="Bildschirmfoto 2025-08-22 um 13 55 44" src="https://github.com/user-attachments/assets/7bd5d8e7-a93a-436c-9ad1-b0b2f1cc7c49" />
<img width="345" height="613" alt="Bildschirmfoto 2025-08-22 um 13 55 53" src="https://github.com/user-attachments/assets/7ed73d19-b1d6-4f77-8043-94b67967249f" />
